### PR TITLE
build(deps): bump hyphen design tokens from 2.0.0 to 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@hyphen/hyphen-design-tokens": "^2.0.0",
+        "@hyphen/hyphen-design-tokens": "^2.0.2",
         "classnames": "^2.5.1",
         "react-select": "^5.8.0"
       },
@@ -2831,9 +2831,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hyphen/hyphen-design-tokens": {
-      "version": "2.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@hyphen/hyphen-design-tokens/2.0.0/bfe1e16b5ffcadf2aa14b8107e802c94120f93e2",
-      "integrity": "sha512-6CrIXALYovccAmhoR9p8ksR2H6Gx1sLxCF66ykBnPfrWlS2lgqX7B8fiR7tn2ZGEgcBkuM51U/QHq7pAlrnrSg==",
+      "version": "2.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@hyphen/hyphen-design-tokens/2.0.2/a56380ada105e96f9c110a7868fb3ecaec2bbcdf",
+      "integrity": "sha512-6ShQfrqK1WTBY+PWPMDRb8Q9bhjFVcmlu7Dz8whgCEV6QGXSxVFQAfqxiDjGgNLdYSLwedtLYNODVyFqVWPu1A==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@rollup/rollup-linux-x64-gnu": "^4.9.6"
   },
   "dependencies": {
-    "@hyphen/hyphen-design-tokens": "^2.0.0",
+    "@hyphen/hyphen-design-tokens": "^2.0.2",
     "classnames": "^2.5.1",
     "react-select": "^5.8.0"
   }


### PR DESCRIPTION
fixes this tertiary color

![Screenshot 2024-02-20 at 10 34 26 AM](https://github.com/Hyphen/hyphen-components/assets/1447339/8cc39acc-ad3d-4901-bd08-27761291fe23)
