### PR TITLE
fix: update Canvas source in TextInputInset component

### DIFF
--- a/src/components/TextInputInset/TextInputInset.mdx
+++ b/src/components/TextInputInset/TextInputInset.mdx
@@ -8,7 +8,7 @@ import * as Stories from './TextInputInset.stories';
 
 Use `TextInputInset` to create a floating label input field. It is a controlled component, which means that you need to provide a value and an `onChange` handler to update the value.
 
-<Canvas withSource="open" of={Stories.Open} />
+<Canvas withSource="open" of={Stories.Default} />
 
 ## Props
 


### PR DESCRIPTION
Altered the source reference in the Canvas markup of the TextInputInset component. The previous reference was set to the non-existing 'Stories.Open' but has now been correctly updated to reference 'Stories.Default'.