### PR TITLE
update error styles for input components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@hyphen/hyphen-components",
-  "version": "2.9.2",
+  "version": "2.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyphen/hyphen-components",
-      "version": "2.9.2",
+      "version": "2.9.4",
       "license": "MIT",
       "dependencies": {
-        "@hyphen/hyphen-design-tokens": "^4.4.2",
+        "@hyphen/hyphen-design-tokens": "^4.4.3",
         "@popperjs/core": "^2.11.8",
         "@types/react-modal": "^3.16.3",
         "classnames": "^2.5.1",
@@ -2841,10 +2841,9 @@
       "dev": true
     },
     "node_modules/@hyphen/hyphen-design-tokens": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@hyphen/hyphen-design-tokens/-/hyphen-design-tokens-4.4.2.tgz",
-      "integrity": "sha512-x5GFsG3Pu5LdvwR6FgLfLS9tfoznZNcMP5TMsu19Q5XzeIGi16jzfo9tVy54ej9F/VKNpn7CKQ3ak2D7N9hNdw==",
-      "license": "MIT",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@hyphen/hyphen-design-tokens/-/hyphen-design-tokens-4.4.3.tgz",
+      "integrity": "sha512-qHPRfvG9vDwQT7RMbrVc8yvIuRkLcpuRUJLhChzYs5RSw9bjFK7OTAZFUn32l5y9hrXivi1g0zLiEPBORHc+2A==",
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@rollup/rollup-linux-x64-gnu": "^4.9.6"
   },
   "dependencies": {
-    "@hyphen/hyphen-design-tokens": "^4.4.2",
+    "@hyphen/hyphen-design-tokens": "^4.4.3",
     "@popperjs/core": "^2.11.8",
     "@types/react-modal": "^3.16.3",
     "classnames": "^2.5.1",

--- a/src/components/SelectInputInset/SelectInputInset.module.scss
+++ b/src/components/SelectInputInset/SelectInputInset.module.scss
@@ -328,11 +328,32 @@
         --form-control-background-color,
         var(--INTERNAL_form-control-background-color)
       );
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-font-color)
+      );
     }
 
+    select, label {
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-input-color-error)
+      );
+    }
     select:focus {
       outline: none;
       background-color: transparent;
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-label-color)
+      );
+      + label {
+        color: var(
+          --form-control-font-color,
+          var(--INTERNAL_form-control-label-color)
+        );
+
+      }
     }
   }
 

--- a/src/components/SelectInputNative/SelectInputNative.module.scss
+++ b/src/components/SelectInputNative/SelectInputNative.module.scss
@@ -337,13 +337,32 @@
       var(--INTERNAL_form-control-background-color-error)
     );
 
-    select:focus {
+    &:focus-within {
       outline: none;
-      border-color: var(
-        --form-control-border-color-focus,
-        var(--INTERNAL_form-control-border-color-focus)
+      border: 1px solid var(--color-border-active);
+      background-color: var(
+        --form-control-background-color,
+        var(--INTERNAL_form-control-background-color)
       );
-      background-color: transparent;
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-font-color)
+      );
+    }
+
+    select {
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-input-color-error)
+      );
+      &:focus {
+        outline: none;
+        background-color: transparent;
+        color: var(
+          --form-control-font-color,
+          var(--INTERNAL_form-control-label-color)
+        );
+      }
     }
   }
 }

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -338,9 +338,20 @@
       );
     }
 
+    input {
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-input-color-error)
+      );
+    }
+
     input:focus {
       outline: none;
       background-color: transparent;
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-font-color)
+      );
     }
   }
 

--- a/src/components/TextInputInset/TextInputInset.module.scss
+++ b/src/components/TextInputInset/TextInputInset.module.scss
@@ -358,10 +358,28 @@
       );
     }
 
+    input, label {
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-input-color-error)
+      );
+    }
+
     input:focus {
       outline: none;
       background-color: transparent;
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-font-color)
+      );
+      + .text-input-label {
+        color: var(
+          --form-control-font-color,
+          var(--INTERNAL_form-control-label-color)
+        );
+      }
     }
+
   }
 
   //Necessary so that inset shadow that we use for border does not get covered by child elements.

--- a/src/components/TextareaInput/TextareaInput.module.scss
+++ b/src/components/TextareaInput/TextareaInput.module.scss
@@ -222,6 +222,10 @@
         --form-control-border-color-focus,
         var(--INTERNAL_form-control-background-color-error)
       );
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-input-color-error)
+      );
     }
 
     textarea:focus {
@@ -238,6 +242,12 @@
         --form-control-border-color-focus,
         var(--INTERNAL_form-control-border-color-focus)
       );
+      > textarea {
+        color: var(
+          --form-control-font-color,
+          var(--INTERNAL_form-control-font-color)
+        );
+      }
     }
   }
 

--- a/src/components/TextareaInputInset/TextareaInputInset.module.scss
+++ b/src/components/TextareaInputInset/TextareaInputInset.module.scss
@@ -288,6 +288,22 @@
       --form-control-background-color-error,
       var(--INTERNAL_form-control-background-color-error)
     );
+    color: var(
+      --form-control-font-color,
+      var(--INTERNAL_form-control-input-color-error)
+    );
+
+    &:focus {
+      outline: none;
+      background-color: transparent;
+    }
+
+    + label {
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-input-color-error)
+      );
+    }
 
     &:focus-within {
       outline: none;
@@ -296,6 +312,20 @@
         --form-control-box-shadow-focus,
         var(--INTERNAL_form-control-box-shadow-focus)
       );
+      background-color: var(
+        --form-control-background-color,
+        var(--INTERNAL_form-control-background-color)
+      );
+      color: var(
+        --form-control-font-color,
+        var(--INTERNAL_form-control-font-color)
+      );
+     + label {
+       color: var(
+         --form-control-font-color,
+         var(--INTERNAL_form-control-label-color)
+       );
+     }
     }
   }
 

--- a/src/styles/variables/forms.scss
+++ b/src/styles/variables/forms.scss
@@ -44,6 +44,7 @@
   --INTERNAL_form-control-font-color: var(--color-font-base);
   --INTERNAL_form-control-font-color-disabled: var(--color-font-disabled);
   --INTERNAL_form-control-font-color-error: var(--color-font-danger);
+  --INTERNAL_form-control-input-color-error: var(--color-font-danger-input);
   --INTERNAL_form-control-font-color-error-disabled: var(
     --color-font-danger-disabled
   );


### PR DESCRIPTION
- [x] TextInput
- Dark Mode
<img width="849" alt="image" src="https://github.com/user-attachments/assets/5828b3f6-a889-4aab-a2d2-673340b5ae82">

- Dark mode on focus
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/facd7f10-5248-47e9-bef2-8511b07b1e1a">

-  Light Mode
<img width="855" alt="image" src="https://github.com/user-attachments/assets/88d222d7-9842-412e-91a4-09a5299ccab8">

- Light Mode on focus
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/5e2a4432-ba2a-4e0a-8f79-e2104930be27">


- [x] TextInputInset
<img width="852" alt="image" src="https://github.com/user-attachments/assets/75d33e4c-ce12-430c-b815-0750990cdcf7">

<img width="851" alt="image" src="https://github.com/user-attachments/assets/25a364ab-6c61-4a34-9ca0-7a9634dc91a8">


- [x] TextareaInput
<img width="856" alt="image" src="https://github.com/user-attachments/assets/13f51203-2bc2-4c6e-9727-70bbdb2d5ea5">

<img width="862" alt="image" src="https://github.com/user-attachments/assets/5d9ef569-9742-494d-9c69-e8114908eb5a">


- [x] TextareInputInset
<img width="703" alt="image" src="https://github.com/user-attachments/assets/febce32b-0332-4cc7-aa39-39bd6464c2d1">

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/b7d3d4fd-1aee-4822-85b6-de022b941de3">


- [x] SelectInputNative
<img width="702" alt="image" src="https://github.com/user-attachments/assets/480e4a50-5e4b-4c30-9617-845cd01ffbc4">

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/94a8a070-fa22-41cb-9f30-92469256625f">



- [x] SelectInputInset
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/1a39dfc1-8228-49ec-9118-36689b16e15d">

<img width="1403" alt="image" src="https://github.com/user-attachments/assets/ec00af60-fb1b-4902-82a9-76f630a58493">