### PR TITLE
docs: simplify light/dark mode switching and preview

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -2,3 +2,4 @@
 <!-- <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"> -->
+<meta name="description" content="React components for Hyphen.ai applications" key="desc" />

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,11 +4,17 @@ import '../src/styles/variables/index.scss';
 import '../src/styles/reset.scss';
 import '../src/styles/fonts.scss';
 
+import { Box } from '../src/components/Box/Box';
 import { Preview } from '@storybook/react';
 import { withThemeByClassName } from '@storybook/addon-themes';
 import hyphenTheme from './hyphenTheme';
 
 export const decorators = [
+  (Story) => (
+    <Box display="block" background="primary" padding="xl">
+      <Story />
+    </Box>
+  ),
   withThemeByClassName({
     themes: {
       light: 'light',
@@ -22,27 +28,6 @@ const preview: Preview = {
   parameters: {
     docs: {
       theme: hyphenTheme,
-    },
-    backgrounds: {
-      default: 'primary (light)',
-      values: [
-        {
-          name: 'primary (light)',
-          value: '#ffffff',
-        },
-        {
-          name: 'secondary (light)',
-          value: '#f5f5f5',
-        },
-        {
-          name: 'primary (dark)',
-          value: '#0a0a0a',
-        },
-        {
-          name: 'secondary (dark)',
-          value: '#171717',
-        },
-      ],
     },
     options: {
       storySort: {


### PR DESCRIPTION
One-click toggling between light and dark modes, with background support.


https://github.com/user-attachments/assets/6952c4be-1bea-49b2-9f55-3ba089d5a29c

