### PR TITLE
fix: handle SSR in prefersReducedMotion

### DIFF
--- a/src/lib/prefersReducedMotion.test.ts
+++ b/src/lib/prefersReducedMotion.test.ts
@@ -1,0 +1,13 @@
+import { prefersReducedMotion } from './prefersReducedMotion';
+
+describe('prefersReducedMotion', () => {
+  it('does not throw and returns true when window is undefined', () => {
+    const originalWindow = (global as any).window;
+    // Simulate server-side environment without window
+    (global as any).window = undefined;
+
+    expect(prefersReducedMotion()).toBe(true);
+
+    (global as any).window = originalWindow;
+  });
+});

--- a/src/lib/prefersReducedMotion.ts
+++ b/src/lib/prefersReducedMotion.ts
@@ -4,7 +4,10 @@ export const prefersReducedMotion = (() => {
 
   return () => {
     if (shouldReduceMotion === undefined) {
-      const mediaQuery = window?.matchMedia('(prefers-reduced-motion: reduce)');
+      const mediaQuery =
+        typeof window !== 'undefined'
+          ? window.matchMedia('(prefers-reduced-motion: reduce)')
+          : undefined;
       shouldReduceMotion = !mediaQuery || mediaQuery.matches;
     }
     return shouldReduceMotion;

--- a/src/lib/prefersReducedMotion.ts
+++ b/src/lib/prefersReducedMotion.ts
@@ -5,8 +5,9 @@ export const prefersReducedMotion = (() => {
   return () => {
     if (shouldReduceMotion === undefined) {
       const mediaQuery =
-        typeof window !== 'undefined'
-          ? window.matchMedia('(prefers-reduced-motion: reduce)')
+        typeof globalThis.window !== 'undefined' &&
+        typeof globalThis.window.matchMedia === 'function'
+          ? globalThis.window.matchMedia('(prefers-reduced-motion: reduce)')
           : undefined;
       shouldReduceMotion = !mediaQuery || mediaQuery.matches;
     }


### PR DESCRIPTION
## Summary
- ensure `prefersReducedMotion` doesn't crash when `window` is undefined
- add test for `prefersReducedMotion` in server environments

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b899034f2c8326b699f625fb3f05f6