### PR TITLE
feat(Icon): microphone, cpu, logo-github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",
-        "@hyphen/hyphen-design-tokens": "^5.1.0",
+        "@hyphen/hyphen-design-tokens": "^5.2.0",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -2739,9 +2739,9 @@
       "dev": true
     },
     "node_modules/@hyphen/hyphen-design-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hyphen/hyphen-design-tokens/-/hyphen-design-tokens-5.1.0.tgz",
-      "integrity": "sha512-6dygACTFk59owzdswzvhXs/i7H5Wzf4z95PiPUbUiAJeoKMU183FeEJgpDWLkgfwZtOTQChtBfmD3rpCDyZ4rw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@hyphen/hyphen-design-tokens/-/hyphen-design-tokens-5.2.0.tgz",
+      "integrity": "sha512-EYbCcVbgwd9akAXlHlmNmYd6LGsl4Fuh/NJPERkLywnwzE/sex8V3l+11AF9AYSFkyC0q/kDE67NV+wkvRKDpA==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   ],
   "dependencies": {
     "@emotion/react": "^11.14.0",
-    "@hyphen/hyphen-design-tokens": "^5.1.0",
+    "@hyphen/hyphen-design-tokens": "^5.2.0",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",


### PR DESCRIPTION
Bump @hyphen/hyphen-design-tokens dependency from version 5.1.0 to 5.2.0 in package.json and package-lock.json.