### PR TITLE
fix: ignore undefined responsive class values

### DIFF
--- a/src/lib/generateResponsiveClasses.test.ts
+++ b/src/lib/generateResponsiveClasses.test.ts
@@ -21,4 +21,13 @@ describe('generateResponsiveClasses', () => {
       'align-items-flex-end-hd',
     ]);
   });
+
+  test('it ignores undefined values in responsive object', () => {
+    const generatedClass = generateResponsiveClasses('align-items', {
+      tablet: undefined,
+      hd: 'flex-end',
+    });
+
+    expect(generatedClass).toEqual(['align-items-flex-end-hd']);
+  });
 });

--- a/src/lib/generateResponsiveClasses.ts
+++ b/src/lib/generateResponsiveClasses.ts
@@ -16,7 +16,10 @@ export function generateResponsiveClasses(
 
   if (typeof value === 'object') {
     Object.keys(value).forEach((key) => {
-      const baseClass = `${classRoot}-${value[key as BreakpointSizeWithBase]}`;
+      const classValue = value[key as BreakpointSizeWithBase];
+      if (classValue === undefined || classValue === null) return;
+
+      const baseClass = `${classRoot}-${classValue}`;
       const responsiveClass =
         key === 'base' ? baseClass : `${baseClass}-${key}`;
 


### PR DESCRIPTION
## Summary
- skip undefined breakpoint values when generating responsive classes
- test responsive class generator ignores undefined values

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf659e04208326bcd2d27b319921a2