### PR TITLE
fix: handle missing matchMedia in prefersReducedMotion

### DIFF
--- a/src/lib/prefersReducedMotion.test.ts
+++ b/src/lib/prefersReducedMotion.test.ts
@@ -1,0 +1,27 @@
+describe('prefersReducedMotion', () => {
+  afterEach(() => {
+    delete (window as any).matchMedia;
+    jest.resetModules();
+  });
+
+  const load = () => require('./prefersReducedMotion').prefersReducedMotion;
+
+  test('returns false when matchMedia is not supported', () => {
+    const result = load()();
+    expect(result).toBe(false);
+  });
+
+  test('returns true when matchMedia matches', () => {
+    (window as any).matchMedia = jest.fn().mockReturnValue({ matches: true });
+    jest.resetModules();
+    const result = load()();
+    expect(result).toBe(true);
+  });
+
+  test('returns false when matchMedia does not match', () => {
+    (window as any).matchMedia = jest.fn().mockReturnValue({ matches: false });
+    jest.resetModules();
+    const result = load()();
+    expect(result).toBe(false);
+  });
+});

--- a/src/lib/prefersReducedMotion.ts
+++ b/src/lib/prefersReducedMotion.ts
@@ -4,8 +4,8 @@ export const prefersReducedMotion = (() => {
 
   return () => {
     if (shouldReduceMotion === undefined) {
-      const mediaQuery = window?.matchMedia('(prefers-reduced-motion: reduce)');
-      shouldReduceMotion = !mediaQuery || mediaQuery.matches;
+      const mediaQuery = window?.matchMedia?.('(prefers-reduced-motion: reduce)');
+      shouldReduceMotion = mediaQuery?.matches ?? false;
     }
     return shouldReduceMotion;
   };


### PR DESCRIPTION
## Summary
- ensure prefersReducedMotion defaults to false when matchMedia is unavailable
- add tests for matchMedia support scenarios

## Testing
- `npm run lint`
- `npm test`
- `npx jest src/lib/prefersReducedMotion.test.ts --runInBand --env=jsdom --config=jest.config.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0565bcb0c8326af968bf69f0ff508