### PR TITLE
chore: Bump @hyphen/hyphen-design-tokens to 5.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",
-        "@hyphen/hyphen-design-tokens": "^5.3.1",
+        "@hyphen/hyphen-design-tokens": "^5.4.0",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -2739,9 +2739,9 @@
       "dev": true
     },
     "node_modules/@hyphen/hyphen-design-tokens": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@hyphen/hyphen-design-tokens/-/hyphen-design-tokens-5.3.1.tgz",
-      "integrity": "sha512-363eUzEqH3lYaNttEZByww/YKK+SPUHh65RuUdVvZ3EBw8zE0fbhyQBCdE2SQznnx8CouoXX1flOMXTdsUHkDQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hyphen/hyphen-design-tokens/-/hyphen-design-tokens-5.4.0.tgz",
+      "integrity": "sha512-phnt0Gq0WP5onLW3dxk3+Oxt7BrI2lsns1JrrO/XQCch+NxZORoc11Ov4+I885fAXXh3GGIXs1VgThVErPkGng==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   ],
   "dependencies": {
     "@emotion/react": "^11.14.0",
-    "@hyphen/hyphen-design-tokens": "^5.3.1",
+    "@hyphen/hyphen-design-tokens": "^5.4.0",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",


### PR DESCRIPTION
Updated the @hyphen/hyphen-design-tokens dependency from version 5.3.1 to 5.4.0 in package.json and package-lock.json.