### PR TITLE
fix: adjust dark secondary button tokens

### DIFF
--- a/packages/design-tokens/tokens/color/background.json
+++ b/packages/design-tokens/tokens/color/background.json
@@ -64,7 +64,7 @@
       },
       "button-secondary-hover": {
         "value": "{color.base.grey.50}",
-        "darkValue": "{color.base.grey.600}"
+        "darkValue": "{color.base.grey.700}"
       },
       "button-secondary-active": {
         "value": "{color.base.grey.100}",

--- a/packages/design-tokens/tokens/color/background.json
+++ b/packages/design-tokens/tokens/color/background.json
@@ -68,7 +68,7 @@
       },
       "button-secondary-active": {
         "value": "{color.base.grey.100}",
-        "darkValue": "{color.base.grey.700}"
+        "darkValue": "{color.base.grey.800}"
       },
       "button-tertiary": {
         "value": "transparent",

--- a/packages/design-tokens/tokens/color/border.json
+++ b/packages/design-tokens/tokens/color/border.json
@@ -55,11 +55,11 @@
       },
       "button-secondary": {
         "value": "{color.base.grey.200}",
-        "darkValue": "{color.base.grey.300}"
+        "darkValue": "{color.base.grey.500}"
       },
       "button-secondary-hover": {
         "value": "{color.base.grey.200}",
-        "darkValue": "{color.base.grey.300}"
+        "darkValue": "{color.base.grey.400}"
       },
       "button-secondary-active": {
         "value": "{color.base.grey.300}",

--- a/packages/design-tokens/tokens/color/border.json
+++ b/packages/design-tokens/tokens/color/border.json
@@ -63,7 +63,7 @@
       },
       "button-secondary-active": {
         "value": "{color.base.grey.300}",
-        "darkValue": "{color.base.grey.400}"
+        "darkValue": "{color.base.grey.300}"
       },
       "button-tertiary": {
         "value": "transparent",

--- a/packages/design-tokens/tokens/color/border.test.js
+++ b/packages/design-tokens/tokens/color/border.test.js
@@ -1,0 +1,11 @@
+const borderTokens = require('./border.json');
+
+describe('border color tokens', () => {
+  test('uses the default dark border color for the secondary button default state', () => {
+    const border = borderTokens.color.border;
+
+    expect(border['button-secondary'].darkValue).toBe(
+      border.default.darkValue
+    );
+  });
+});


### PR DESCRIPTION
Update secondary button dark-mode color tokens to use stronger border/background values: `background.button-secondary-hover` now maps to `grey.700`, `border.button-secondary` to `grey.500`, and `border.button-secondary-hover` to `grey.400`. Also add a border token test to ensure the default secondary button dark border stays aligned with `border.default.darkValue`.