### PR TITLE
feat(Button): add success variant

### DIFF
--- a/packages/components/src/components/Button/Button.constants.ts
+++ b/packages/components/src/components/Button/Button.constants.ts
@@ -5,6 +5,7 @@ export const BUTTON_VARIANTS: ButtonVariant[] = [
   'secondary',
   'tertiary',
   'danger',
+  'success',
 ];
 
 export const BUTTON_SIZES: ButtonSize[] = ['sm', 'md', 'lg'];

--- a/packages/components/src/components/Button/Button.module.scss
+++ b/packages/components/src/components/Button/Button.module.scss
@@ -3,7 +3,8 @@
 :root {
   --button-box-shadow-focus: 0 0 0 4px var(--color-base-grey-300);
   --button-neutral-box-shadow-focus: 0 0 0 4px var(--color-base-grey-200);
-  --button-danger-box-shadow-focus: 0 0 0 4px var(--color-base-danger-200);
+  --button-danger-box-shadow-focus: 0 0 0 4px var(--color-base-red-200);
+  --button-success-box-shadow-focus: 0 0 0 4px var(--color-base-green-200);
 }
 
 @mixin size-sm {
@@ -237,6 +238,36 @@
     &:focus-visible {
       outline: 0;
       box-shadow: var(--button-danger-box-shadow-focus);
+    }
+
+    &:focus:not(:focus-visible) {
+      outline: 0;
+      box-shadow: none;
+    }
+  }
+
+  &.success {
+    background-color: var(--color-background-button-success);
+    color: var(--color-font-button-success);
+
+    &:not(:disabled):hover {
+      background-color: var(--color-background-button-success-hover);
+      color: var(--color-font-button-success-hover);
+    }
+
+    &:not(:disabled):active {
+      background-color: var(--color-background-button-success-active);
+      color: var(--color-font-button-success-active);
+    }
+
+    &:focus {
+      outline: 0;
+      box-shadow: var(--button-success-box-shadow-focus);
+    }
+
+    &:focus-visible {
+      outline: 0;
+      box-shadow: var(--button-success-box-shadow-focus);
     }
 
     &:focus:not(:focus-visible) {

--- a/packages/components/src/components/Button/Button.stories.tsx
+++ b/packages/components/src/components/Button/Button.stories.tsx
@@ -11,6 +11,7 @@ const BUTTON_VARIANTS: ButtonVariant[] = [
   'secondary',
   'tertiary',
   'danger',
+  'success',
   'link',
 ];
 const BUTTON_SIZES: ButtonSize[] = ['sm', 'md', 'lg'];

--- a/packages/components/src/components/Button/Button.test.tsx
+++ b/packages/components/src/components/Button/Button.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BUTTON_SIZES, BUTTON_VARIANTS } from './Button.constants';
-import { Button, ButtonVariant } from './Button';
+import { Button } from './Button';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 const renderButton = (props = {}) => render(<Button {...props} />);
@@ -307,7 +307,7 @@ describe('Button', () => {
         expect(spinnerElement).toBeInTheDocument();
       });
 
-      test('renders white spinning indicator when button is success', () => {
+      test('renders the spinning indicator when button is success', () => {
         renderButton({
           isLoading: true,
           variant: 'success',
@@ -335,14 +335,7 @@ describe('Button', () => {
         expect(getButton('primary')).toHaveClass('primary');
       });
 
-      const variants: ButtonVariant[] = [
-        'primary',
-        'secondary',
-        'tertiary',
-        'danger',
-        'success',
-      ];
-      variants.forEach((variant) => {
+      BUTTON_VARIANTS.forEach((variant) => {
         test(`renders component with variant: ${variant} when passed`, () => {
           renderButton({ variant, children: variant });
           expect(getButton(variant)).toHaveClass(variant);

--- a/packages/components/src/components/Button/Button.test.tsx
+++ b/packages/components/src/components/Button/Button.test.tsx
@@ -306,6 +306,16 @@ describe('Button', () => {
         const spinnerElement = document.getElementsByClassName('spinner')[0];
         expect(spinnerElement).toBeInTheDocument();
       });
+
+      test('renders white spinning indicator when button is success', () => {
+        renderButton({
+          isLoading: true,
+          variant: 'success',
+          children: 'Button is loading',
+        });
+        const spinnerElement = document.getElementsByClassName('spinner')[0];
+        expect(spinnerElement).toBeInTheDocument();
+      });
     });
 
     describe('Disabled and Loading', () => {
@@ -330,6 +340,7 @@ describe('Button', () => {
         'secondary',
         'tertiary',
         'danger',
+        'success',
       ];
       variants.forEach((variant) => {
         test(`renders component with variant: ${variant} when passed`, () => {

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -13,6 +13,7 @@ export type ButtonVariant =
   | 'secondary'
   | 'tertiary'
   | 'danger'
+  | 'success'
   | 'link';
 
 export type ButtonSize = 'sm' | 'md' | 'lg';

--- a/packages/design-tokens/tokens/color/background.json
+++ b/packages/design-tokens/tokens/color/background.json
@@ -94,6 +94,18 @@
         "value": "{color.base.red.700}",
         "darkValue": "{color.base.red.700}"
       },
+      "button-success": {
+        "value": "{color.base.green.600}",
+        "darkValue": "{color.base.green.600}"
+      },
+      "button-success-hover": {
+        "value": "{color.base.green.700}",
+        "darkValue": "{color.base.green.700}"
+      },
+      "button-success-active": {
+        "value": "{color.base.green.800}",
+        "darkValue": "{color.base.green.800}"
+      },
       "badge-default": {
         "value": "{color.base.grey.800}",
         "darkValue": "{color.base.white}"

--- a/packages/design-tokens/tokens/color/font.json
+++ b/packages/design-tokens/tokens/color/font.json
@@ -106,6 +106,15 @@
       "button-danger-active": {
         "value": "{color.base.white}"
       },
+      "button-success": {
+        "value": "{color.base.white}"
+      },
+      "button-success-hover": {
+        "value": "{color.base.white}"
+      },
+      "button-success-active": {
+        "value": "{color.base.white}"
+      },
       "badge-default": {
         "value": "{color.base.white}",
         "darkValue": "{color.base.grey.800}"


### PR DESCRIPTION
## Summary

Adds a solid green `success` variant to `Button`, for affirmative actions like Save, Approve, and Confirm. Until now those had to borrow `primary` (neutral grey) or hand-roll a green button outside the token system.

The variant mirrors `danger` structurally — solid fill, white label, no border, its own focus ring — and is driven entirely by new `button-success*` design tokens.

## Colour choice

`danger` uses red 500/600/700. `success` deliberately sits one step darker at **green 600/700/800**:

| | background | white text contrast |
|---|---|---|
| `danger` (existing) | `#ef4444` | 3.8:1 — fails WCAG AA |
| `success` (new) | `#15803d` | **5.0:1 — passes WCAG AA** |

Matching danger's scale exactly would have landed at 3.3:1. There was no reason to inherit that, so the new variant is accessible from the start.

Light and dark values are identical, following the same convention as `danger`.

## Drive-by fix

The `danger` focus ring referenced `--color-base-danger-200`, a variable that has never existed — the scale is `--color-base-red-*`. The ring silently rendered nothing. Now corrected to `--color-base-red-200`, so **the danger button gains a visible focus ring it should always have had**. This is a real visual change to an existing variant, worth a look during review.

## Changes

**Design tokens** — `packages/design-tokens/tokens/color/`
- `background.json` — `button-success`, `button-success-hover`, `button-success-active`
- `font.json` — matching white label tokens

**Component** — `packages/components/src/components/Button/`
- `Button.tsx` — `'success'` added to the exported `ButtonVariant` union
- `Button.module.scss` — `&.success` block mirroring `&.danger`; adds `--button-success-box-shadow-focus`; fixes the danger ring
- `Button.constants.ts` / `Button.stories.tsx` / `Button.test.tsx` — the variant list is duplicated across all three, so each needed updating; plus a new loading-spinner test

```
 packages/components/src/components/Button/Button.constants.ts |  1 +
 packages/components/src/components/Button/Button.module.scss  | 33 ++++++++++-
 packages/components/src/components/Button/Button.stories.tsx  |  1 +
 packages/components/src/components/Button/Button.test.tsx     | 11 +++++
 packages/components/src/components/Button/Button.tsx          |  1 +
 packages/design-tokens/tokens/color/background.json           | 12 ++++++
 packages/design-tokens/tokens/color/font.json                 |  9 ++++
 7 files changed, 67 insertions(+), 1 deletion(-)
```

`Button.mdx` renders `<Canvas of={Stories.Variants} />` with no hardcoded list, so docs pick this up automatically.

## Breaking changes

None. `ButtonVariant` is widened, not narrowed. It isn't shared with any other component — `Alert`, `Badge`, and `Toggle` have independent unions — and every internal consumer (`Pagination`, `Drawer`, `Sidebar`, `ModalHeader`) passes a literal rather than exhaustively switching.

## Testing

- `pnpm --filter @hyphen/hyphen-components test -- Button.test` — 56 passing, including the new `success` cases
- `pnpm lint` — clean
- Tokens regenerate to `#15803d` in both `variables.css` and `variables-root-dark.css`
- Verified in Storybook: renders `rgb(21,128,61)` with white text; keyboard Tab produces `:focus-visible` and the pale green ring `#bbf7d0`, while mouse focus correctly produces none; the danger ring now resolves to `#fecaca` where it previously resolved to nothing

**Not visually verified:** Storybook's dark-mode toggle. The generated dark CSS carries the identical `#15803d`, so nothing *can* differ — but I confirmed that at the token layer, not by eye. Worth a glance in Chromatic.

## Review notes

- The variant list lives in **three unsynced places** (`Button.constants.ts`, the stories, the test). All three are updated here, but it's a trap for the next person adding a variant — follow-up refactor suggested.
- Should `success` also get a bordered/secondary treatment, or is solid-only right for now?